### PR TITLE
POC for eval functionality in go

### DIFF
--- a/poc/eval.go
+++ b/poc/eval.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"github.com/traefik/yaegi/interp"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func main() {
+	http.HandleFunc("/eval", evalHandler)
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func evalHandler(rw http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(rw, "Error reading request body", http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Printf("Raw data received data: %s\n", string(body))
+	keyValuePairs := getKeyValuePairs(string(body))
+	fmt.Printf("Function provided: %s\n", keyValuePairs["function"])
+	fmt.Printf("Method inputs provided: %s\n", keyValuePairs["args"])
+
+	// eval impl
+	i := interp.New(interp.Options{})
+
+	_, err = i.Eval(keyValuePairs["function"])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	result, err := i.Eval(keyValuePairs["args"])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Output:", result)
+	response := fmt.Sprintf("Result: %v", result)
+	rw.Write([]byte(response))
+}
+
+func getKeyValuePairs(s string) map[string]string {
+	pairs := make(map[string]string)
+
+	for _, pair := range strings.Split(s, "&") {
+		parts := strings.Split(pair, "=")
+		if len(parts) == 2 {
+			key, value := parts[0], parts[1]
+			pairs[key] = value
+		}
+	}
+
+	return pairs
+}

--- a/poc/go.mod
+++ b/poc/go.mod
@@ -1,0 +1,5 @@
+module shrinksync
+
+go 1.21.1
+
+require github.com/traefik/yaegi v0.15.1


### PR DESCRIPTION
Solves #10 


## Eval in go
- https://github.com/apaxa-go/eval - This supports only basic expression evaluators
- https://github.com/traefik/yaegi - Best other good alternative. Went ahead with this as this support complex function runs

Lot's of articles mentioned that `eval()` sort of function was intentionally not provided in go because its statically typed language as opposed to python/ts. Maybe we should revisit this?


## Testing:
Send out a curl request similar to `curl -X POST --data-raw 'function=func add(x, y int)int{return x+y}&args=add(3,4)' http://localhost:8080/eval`  you should see the result of expression given as response

