### PR TITLE
added module release github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,17 +11,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go version
         uses: actions/setup-go@v2
         with:
           go-version: '1.21.5'
-
-      - name: Set up Git
-        run: |
-          git config --global user.email "reethu.vinta@gmail.com"
-          git config --global user.name "Reethu Vinta"
 
       - name: Build and test Go module
         run: |
@@ -29,35 +24,24 @@ jobs:
           go build ./...
           go test ./...
 
-      - name: Determine Version
-        id: determine_version
+      - name: Set up Git
         run: |
-          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          IFS='.' read -r major minor patch <<< "$VERSION"
-          if [ "$VERSION" = "v0.0.0" ]; then
-            NEXT_VERSION="v0.0.0"
-          else
-            NEXT_VERSION="$major.$minor.$((patch + 1))"
-          fi  
-          echo "::set-output name=next_version::$NEXT_VERSION"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Determine Version
+        run: |
+          git fetch --tags
+          latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+          IFS='.' read -r major minor patch <<< "$latest_tag"
+          NEXT_VERSION="$major.$minor.$((patch + 1))"
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_ENV
 
       - name: Create Release Tag
-        id: create_tag
         run: |
-          git tag -a ${{ steps.determine_version.outputs.next_version }} -m "Release ${{ steps.determine_version.outputs.next_version }}"
-          echo "::set-output name=tag::${{ steps.determine_version.outputs.next_version }}"
+          git tag -a ${{ env.next_version }} -m "Release ${{ env.next_version }}"
+          echo "tag=${{ env.next_version }}" >> $GITHUB_ENV
 
       - name: Push Tag to Repository
-        run: git push origin ${{ steps.create_tag.outputs.tag }}
-
-      - name: Index ShrinkSync Module
-        run: GOPROXY=proxy.golang.org go list -m github.com/SystemsStuff/ShrinkSync@${{ steps.create_tag.outputs.tag }}     
-           
-      - name: Verify release
         run: |
-          if go get github.com/SystemsStuff/ShrinkSync@${{ steps.create_tag.outputs.tag }}; then
-            echo "Version released successfully"
-          else
-            echo "Something went wrong with the release. Please check!"
-            exit 1
-          fi           
+          git push origin ${{ env.tag }}


### PR DESCRIPTION
Resolves #26 

- added github action for the releases of the module


**Note:**
- Go has good, simpler way to publish modules. You just need to create a tag,  list it. Voila! anyone can use the package now! ref: https://go.dev/doc/modules/publishing
- This action creates new patch version for every commit
- If major/minor version needs to be updated, it has to be done manually once done it will pick the updated one for the next commits release
- PS: Haven't published our module yet. Once cleanup is done we can publish the v.0.0.0 version.
- PPS: Once this PR is merged, for the next merge on main branch this action will get triggered. So once this is merged, let's next merge the clean up one which will trigger v0.0.0 release